### PR TITLE
Upgrade build tool and dependencies

### DIFF
--- a/1-base/build.gradle
+++ b/1-base/build.gradle
@@ -18,13 +18,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.android.example.watchface"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -34,9 +34,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    return void
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.1.0'
-    compile 'com.google.android.gms:play-services-wearable:6.5.87'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }

--- a/1-base/build.gradle
+++ b/1-base/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 
 
+//noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -34,7 +35,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    return void
 }
 
 dependencies {

--- a/2-background/build.gradle
+++ b/2-background/build.gradle
@@ -18,13 +18,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.android.example.watchface"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -34,9 +34,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    return void
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.1.0'
-    compile 'com.google.android.gms:play-services-wearable:6.5.87'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }

--- a/2-background/build.gradle
+++ b/2-background/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 
 
+//noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -34,7 +35,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    return void
 }
 
 dependencies {

--- a/3-hands/build.gradle
+++ b/3-hands/build.gradle
@@ -18,13 +18,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.android.example.watchface"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -34,9 +34,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    return void
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.1.0'
-    compile 'com.google.android.gms:play-services-wearable:6.5.87'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }

--- a/3-hands/build.gradle
+++ b/3-hands/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 
 
+//noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -34,7 +35,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    return void
 }
 
 dependencies {

--- a/4-ambient/build.gradle
+++ b/4-ambient/build.gradle
@@ -18,13 +18,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.android.example.watchface"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -34,9 +34,10 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    return void
 }
 
 dependencies {
-    compile 'com.google.android.support:wearable:1.1.0'
-    compile 'com.google.android.gms:play-services-wearable:6.5.87'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }

--- a/4-ambient/build.gradle
+++ b/4-ambient/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 
 
+//noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -34,7 +35,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    return void
 }
 
 dependencies {

--- a/5-palette/build.gradle
+++ b/5-palette/build.gradle
@@ -17,6 +17,7 @@
 apply plugin: 'com.android.application'
 
 
+//noinspection GroovyMissingReturnStatement
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.2"
@@ -35,7 +36,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
-    return void
 }
 
 dependencies {

--- a/5-palette/build.gradle
+++ b/5-palette/build.gradle
@@ -18,15 +18,16 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.2"
 
     defaultConfig {
         applicationId "com.android.example.watchface"
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
+        multiDexEnabled true
     }
     buildTypes {
         release {
@@ -34,10 +35,12 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt')
         }
     }
+    return void
 }
 
 dependencies {
-    compile 'com.android.support:palette-v7:21.0.0'
-    compile 'com.google.android.support:wearable:1.1.0'
-    compile 'com.google.android.gms:play-services-wearable:6.5.87'
+    compile 'com.android.support:palette-v7:25.1.0'
+    compile 'com.google.android.support:wearable:1.4.0'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
+    compile 'com.android.support:multidex:1.0.1'
 }

--- a/5-palette/src/main/AndroidManifest.xml
+++ b/5-palette/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <application
+        android:name="android.support.multidex.MultiDexApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:theme="@android:style/Theme.DeviceDefault"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Tue Dec 20 13:06:56 CET 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
# Common
gradle version : gradle-2.14.1(gradle-wrapper.properties)
android.tools.build:gradle:2.2.3 (build.gradle)
# All projects
The following items are upgraded in every sub-project (build.gradle): 
- build tools 25.0.2
- support:wearable:1.4.0
- play-services-wearable:10.0.1
# 5-palette
In addition to changes mentioned above, this item was also upgraded:
support:palette-v7:25.1.0
The addition of all these upgrades caused the threshold of 64K methods to be exceeded, therefore requiring this app to be converted in **MultiDexApplication**